### PR TITLE
fix: Access href only if document is present for the key

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,12 +84,13 @@ function getNav(doc, allDocs, config) {
       if (!checkAllowed(key, config)) return;
       if (!allDocs[key] && allDocs[key + '/index']) key = key + '/index';
     }
-    const title = d.title || allDocs[key].frontMatter.title;
+    const title = d.title || (allDocs[key] && allDocs[key].frontMatter.title || "");
+    const href = key && allDocs[key] && allDocs[key].href
 
     const item = {
       key,
       title,
-      href: key && allDocs[key].href,
+      href,
       level,
       children: [],
       active: key === doc.key,

--- a/server.js
+++ b/server.js
@@ -84,13 +84,12 @@ function getNav(doc, allDocs, config) {
       if (!checkAllowed(key, config)) return;
       if (!allDocs[key] && allDocs[key + '/index']) key = key + '/index';
     }
-    const title = d.title || (allDocs[key] && allDocs[key].frontMatter.title || "");
-    const href = key && allDocs[key] && allDocs[key].href
+    const title = d.title || (allDocs[key]?.frontMatter.title || "");
 
     const item = {
       key,
       title,
-      href,
+      href: key && allDocs[key]?.href,
       level,
       children: [],
       active: key === doc.key,


### PR DESCRIPTION
Documents for certain keys are not present. Hence the build is throwing error on trying to access the same. Fix that by checking whether a document is present before accessing it's properties
