### PR TITLE
fix: Fix image breaking the numbering in a numbered list

### DIFF
--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -11,12 +11,12 @@ const blockRules = {
   // use it to comment in markdown
   '//': (a) => '',
 
-  image: function(rest, config) {
+  image: function (rest, config) {
     return `<img src="/${config.publicPath}/assets/images/${rest[0]}"/>`;
   },
 
   // include another markdown
-  include: function(rest, config) {
+  include: function (rest, config) {
     /* Sample use in *.md files */
     // e.g. @include part1
     return cfs.readSync(`${config.partials}/${rest[0]}.md`);
@@ -28,36 +28,36 @@ function getAttrs(openTag) {
   const parser = new htmlparser.Parser({
     onopentag(name, _attrs) {
       attrs = _attrs;
-    }
+    },
   });
   parser.write(openTag);
   parser.end();
   return attrs;
-};
+}
 
-module.exports = function(body, config) {
-  return body.replace(/^\s*<img([^>]*)\/?>/mg, function(openTag) {
-    attrs = getAttrs(openTag);
-    if (attrs.src) {
-      attrs.src = attrs.src.replace(/^\/docs\//, config.publicPath);
-    }
-    attrs.class = 'click-zoom';
-    return `\n<img${Object.keys(attrs).map(k => ` ${k}="${attrs[k]}"`)}>\n`;
-  }).replace(/^(\s*)@(\/\/|image|include)(.*)$/mg, function(
-    _,
-    indent,
-    rule,
-    rest,
-  ) {
-    rest = rest.split(/\s+/).filter(_ => _);
-    return blockRules[rule](rest, config);
-  }).replace(/^(<show-if[^>]*>)(.*?)^<\/show-if>/mgs, function(
-    _,
-    openTag,
-    content,
-  ) {
-    attrs = getAttrs(openTag);
-    if (config.org === attrs.org) return content;
-    return '';
-  })
+module.exports = function (body, config) {
+  return body
+    .replace(/^(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
+      attrs = getAttrs(openTag);
+      if (attrs.src) {
+        attrs.src = attrs.src.replace(/^\/docs\//, config.publicPath);
+      }
+      attrs.class = 'click-zoom';
+      return `\n${indent}<img${Object.keys(attrs).map((k) => ` ${k}="${attrs[k]}"`)}>\n`;
+    })
+    .replace(
+      /^(\s*)@(\/\/|image|include)(.*)$/gm,
+      function (_, indent, rule, rest) {
+        rest = rest.split(/\s+/).filter((_) => _);
+        return blockRules[rule](rest, config);
+      }
+    )
+    .replace(
+      /^(<show-if[^>]*>)(.*?)^<\/show-if>/gms,
+      function (_, openTag, content) {
+        attrs = getAttrs(openTag);
+        if (config.org === attrs.org) return content;
+        return '';
+      }
+    );
 };


### PR DESCRIPTION
Image replace in at rules does not take the indent into consideration. This breaks the markdown rendering logic of numbered lists. Fix the same by considering the indent of an image tag