### PR TITLE
feat: Rewrite internal links based on public path

### DIFF
--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -37,14 +37,6 @@ function getAttrs(openTag) {
 
 module.exports = function (body, config) {
   return body
-    .replace(/^(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
-      attrs = getAttrs(openTag);
-      if (attrs.src) {
-        attrs.src = attrs.src.replace(/^\/docs\//, config.publicPath);
-      }
-      attrs.class = 'click-zoom';
-      return `\n${indent}<img${Object.keys(attrs).map((k) => ` ${k}="${attrs[k]}"`)}>\n`;
-    })
     .replace(
       /^(\s*)@(\/\/|image|include)(.*)$/gm,
       function (_, indent, rule, rest) {
@@ -58,6 +50,36 @@ module.exports = function (body, config) {
         attrs = getAttrs(openTag);
         if (config.org === attrs.org) return `${indent}${content}`;
         return '';
+      }
+    )
+    .replace(/^(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
+      attrs = getAttrs(openTag);
+      if (attrs.src) {
+        const isInternalImage = attrs.src.startsWith('/docs/');
+        if (isInternalImage) {
+          attrs.src = attrs.src.replace(/^\/docs\//, config.publicPath);
+        }
+      }
+      attrs.class = 'click-zoom';
+      const updatedAttrs = Object.keys(attrs)
+        .map((k) => ` ${k}="${attrs[k]}"`)
+        .join(' ');
+      return `\n${indent}<img${updatedAttrs}>\n`;
+    })
+    .replace(
+      /(\s*)(<a([^>]*?)>)(.*?)<\/a>/gm,
+      function (_, indent, openTag, __, content) {
+        attrs = getAttrs(openTag);
+        if (attrs.href) {
+          const isInternalLink = attrs.href.startsWith('/docs/');
+          if (isInternalLink) {
+            attrs.href = attrs.href.replace(/^\/docs\//, config.publicPath);
+          }
+        }
+        const updatedAttrs = Object.keys(attrs)
+          .map((k) => ` ${k}="${attrs[k]}"`)
+          .join(' ');
+        return `${indent}<a${updatedAttrs}>${content}</a>`;
       }
     );
 };

--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -4,6 +4,7 @@ const readFileSync = (file) => fs.readFileSync(file, 'utf8');
 const noop = () => {};
 const cfs = require('./cfs');
 const htmlparser = require('htmlparser2');
+const customLink = require('./custom-link');
 
 // block rules are always functions
 // called with `md` as context
@@ -71,10 +72,7 @@ module.exports = function (body, config) {
       function (_, indent, openTag, __, content) {
         attrs = getAttrs(openTag);
         if (attrs.href) {
-          const isInternalLink = attrs.href.startsWith('/docs/');
-          if (isInternalLink) {
-            attrs.href = attrs.href.replace(/^\/docs\//, config.publicPath);
-          }
+          attrs.href = customLink(attrs.href, config);
         }
         const updatedAttrs = Object.keys(attrs)
           .map((k) => ` ${k}="${attrs[k]}"`)

--- a/scripts/custom-link.js
+++ b/scripts/custom-link.js
@@ -1,0 +1,7 @@
+module.exports = function customLink(url, config) {
+  const isInternalLink = url.startsWith('/docs/');
+  if (isInternalLink) {
+    return url.replace(/^\/docs\//, config.publicPath);
+  }
+  return url;
+};

--- a/scripts/md.js
+++ b/scripts/md.js
@@ -4,16 +4,17 @@ const deflist = require('markdown-it-deflist');
 const anchor = require('markdown-it-anchor');
 const customHtml = require('./html_block');
 const customFence = require('./fence');
+const customLink = require('./custom-link');
 
 hljs.registerLanguage('curl', require('highlight.js/lib/languages/bash'));
 
 let openTags;
 let anchors;
-const tokenFn = state => (type, tag, nesting, opts) => {
+const tokenFn = (state) => (type, tag, nesting, opts) => {
   const token = new state.Token(type, tag, nesting);
   if (opts) return Object.assign(token, opts);
   return token;
-}
+};
 
 const renderPermalink = (slug, opts, state, idx) => {
   const href = opts.permalinkHref(slug, state);
@@ -24,65 +25,100 @@ const renderPermalink = (slug, opts, state, idx) => {
         ['class', 'header-link'],
         ['href', href],
         ['name', href.slice(1)],
-      ]
+      ],
     }),
     ...state.tokens[idx + 1].children,
-    token('html_inline', '', 0, { content: `<span class='header-anchor'>${opts.permalinkSymbol}</span>`}),
+    token('html_inline', '', 0, {
+      content: `<span class='header-anchor'>${opts.permalinkSymbol}</span>`,
+    }),
     token('link_close', 'a', -1),
-  ]
+  ];
   const tag = state.tokens[idx].tag;
   if (tag === 'h2' || tag === 'h1') {
     anchors.push({
       href,
       level: tag.slice(1),
       title: state.tokens[idx + 1].children
-        .filter(token => token.type === 'text' || token.type === 'code_inline')
-        .reduce((acc, t) => acc + t.content, '')
+        .filter(
+          (token) => token.type === 'text' || token.type === 'code_inline'
+        )
+        .reduce((acc, t) => acc + t.content, ''),
     });
     const wrapper = tag === 'h2' ? 'section' : 'article';
     if (openTags.hasOwnProperty(wrapper)) {
       if (tag === 'h1' && openTags.section) {
-        state.tokens.splice(idx++, 0, token('html_inline', '', 0, { content: `</section>`}));
+        state.tokens.splice(
+          idx++,
+          0,
+          token('html_inline', '', 0, { content: `</section>` })
+        );
       }
-      state.tokens.splice(idx++, 0, token('html_inline', '', 0, { content: `</${wrapper}>`}));
+      state.tokens.splice(
+        idx++,
+        0,
+        token('html_inline', '', 0, { content: `</${wrapper}>` })
+      );
     } else {
       openTags[wrapper] = true;
     }
-    state.tokens.splice(idx, 0, token('html_inline', '', 0, { content: `<${wrapper}>`}));
+    state.tokens.splice(
+      idx,
+      0,
+      token('html_inline', '', 0, { content: `<${wrapper}>` })
+    );
   }
   state.tokens[idx + 2].children = linkTokens;
+};
+
+function getMd(config) {
+  const md = markdownIt({
+    html: true,
+    langPrefix: 'lang lang-',
+    highlight: (str, lang) => {
+      if (lang && hljs.getLanguage(lang)) {
+        try {
+          return hljs.highlight(lang, str).value;
+        } catch (e) {}
+      }
+      return str;
+    },
+  })
+    .disable(['table', 'lheading', 'hr', 'html_block'])
+    .use(deflist)
+    .use(anchor, {
+      permalink: true,
+      permalinkSymbol: '🔗',
+      slugify: (s) =>
+        s
+          .toLowerCase()
+          .split(/\s+/g, 8)
+          .join('-')
+          .replace(/[^-\w]/g, ''),
+      renderPermalink,
+    });
+
+  md.block.ruler.before('heading', 'custom_html_block', customHtml(md));
+  md.block.ruler.at('fence', customFence(md));
+  const normalizeLink = md.normalizeLink;
+  md.normalizeLink = (url) => {
+    //rewrite url
+    console.log('link ', url);
+    const customUrl = customLink(url, config);
+    console.log('Normalize link ', customUrl);
+    return normalizeLink(customUrl);
+  };
+  return md;
 }
 
-const md = markdownIt({
-  html: true,
-  langPrefix: 'lang lang-',
-  highlight: (str, lang) => {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return hljs.highlight(lang, str).value;
-      } catch (e) {}
-    }
-    return str;
-  },
-})
-.disable(['table', 'lheading', 'hr', 'html_block'])
-.use(deflist)
-.use(anchor, {
-  permalink: true,
-  permalinkSymbol: '🔗',
-  slugify: s => s.toLowerCase().split(/\s+/g, 8).join('-').replace(/[^-\w]/g, ''),
-  renderPermalink,
-});
-
-md.block.ruler.before('heading', 'custom_html_block', customHtml(md));
-md.block.ruler.at('fence', customFence(md));
-
-module.exports = (content) => {
-  openTags = {};
-  anchors = [];
-  content = md.render(content);
-  return {
-    anchors,
-    content,
-  }
-}
+module.exports = (config) => {
+  const md = getMd(config);
+  return (content) => {
+    openTags = {};
+    anchors = [];
+    content = md.render(content);
+    return {
+      anchors,
+      content,
+    };
+  };
+};

--- a/scripts/md.js
+++ b/scripts/md.js
@@ -101,10 +101,7 @@ function getMd(config) {
   md.block.ruler.at('fence', customFence(md));
   const normalizeLink = md.normalizeLink;
   md.normalizeLink = (url) => {
-    //rewrite url
-    console.log('link ', url);
     const customUrl = customLink(url, config);
-    console.log('Normalize link ', customUrl);
     return normalizeLink(customUrl);
   };
   return md;

--- a/server.js
+++ b/server.js
@@ -61,6 +61,13 @@ async function generateCss({ config }) {
 function generateJs({ config }) {
   const webpackConfig = {
     ...webpackConfigBase,
+    plugins: [
+      ...webpackConfigBase.plugins,
+      new webpack.DefinePlugin({
+        ORG: JSON.stringify(config.org),
+        PUBLIC_PATH: JSON.stringify(config.publicPath),
+      }),
+    ],
     entry: process.env.PWD + '/' + config.js,
     output: {
       path: path.resolve(config.dist),

--- a/server.js
+++ b/server.js
@@ -66,6 +66,7 @@ function generateJs({ config }) {
       new webpack.DefinePlugin({
         ORG: JSON.stringify(config.org),
         PUBLIC_PATH: JSON.stringify(config.publicPath),
+        DASHBOARD_URL: JSON.stringify(config.dashboardUrl),
       }),
     ],
     entry: process.env.PWD + '/' + config.js,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const isProd = process.env.NODE_ENV === 'production';
 module.exports = {
   mode: isProd ? 'production' : 'development',
   resolve: {
-    modules: process.env.NODE_PATH.split(':').filter(_=>_),
-  }
-}
+    modules: process.env.NODE_PATH.split(':').filter((_) => _),
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Internal links are defined by content writers with the base url as /docs/...
This works for prod razorpay docs as the public path is /docs/. Update the urls to automatically take the public path in config as the base url