### PR TITLE
fix: Make redirect file creation synchronous

### DIFF
--- a/create-redirects.js
+++ b/create-redirects.js
@@ -1,21 +1,19 @@
 const yaml = require('js-yaml');
-const { exec } = require('child_process');
-const fs = require('fs').promises;
+const { execSync } = require('child_process');
+const fs = require('fs');
 
-async function createRedirects(config) {
+function createRedirects(config) {
   const BASE_PATH = config.basePath + config.publicPath;
   const DIST_DIR = config.dist;
   const REDIRECTS_FILE_PATH = process.env.PWD + '/' + config.redirects;
-  const redirectContent = await fs.readFile(REDIRECTS_FILE_PATH);
+  const redirectContent = fs.readFileSync(REDIRECTS_FILE_PATH);
   const redirects = yaml.load(redirectContent);
-  await Promise.all(
-    Object.keys(redirects).map(async (origin) => {
-      const url = new URL(BASE_PATH + redirects[origin]);
-      const html = `<html><head><meta http-equiv="refresh" content="0;URL=${url}"/></head></html>`;
-      await exec(`mkdir -p ${DIST_DIR}/${origin}/`);
-      await fs.writeFile(`${DIST_DIR}/${origin}/index.html`, html);
-    })
-  );
+  Object.keys(redirects).map((origin) => {
+    const url = new URL(BASE_PATH + redirects[origin]);
+    const html = `<html><head><meta http-equiv="refresh" content="0;URL=${url}"/></head></html>`;
+    execSync(`mkdir -p ${DIST_DIR}/${origin}/`);
+    fs.writeFileSync(`${DIST_DIR}/${origin}/index.html`, html);
+  })
 }
 
 module.exports = createRedirects;

--- a/server.js
+++ b/server.js
@@ -185,7 +185,7 @@ async function build({ config, getDoc, docs, getKey, allDocs }) {
     const filepath = config.dist + '/' + doc.href + '/index.html';
     cfs.write(filepath, html);
   });
-  await createRedirects(config);
+  createRedirects(config);
   config.plugins.forEach(cleanupPlugin);
 }
 


### PR DESCRIPTION
Async redirect file creation keeps too many open descriptors and fails. Making it synchronous