### PR TITLE
fix(Plugins): Send frontmatter to plugins

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,9 +85,10 @@ function getNav(doc, allDocs, config) {
 function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
   let content = atRules(doc.body, config);
   const parsedContent = markdown(content, config);
+  const parsedContentWithFrontmatter = { ...parsedContent, ...doc.frontMatter };
   const result = config.plugins.reduce(function (acc, plugin) {
     return applyPlugin({ plugin, content: acc });
-  }, parsedContent);
+  }, parsedContentWithFrontmatter);
   return pugCompiler({
     ...doc,
     ...result,


### PR DESCRIPTION
Currently, the plugins only get the content and associated anchors for a page. This pr adds frontmatter to it. 