### PR TITLE
fix(plugins): Send document url to plugins

### DIFF
--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
   const parsedContentWithFrontmatter = {
     ...parsedContent,
     ...doc.frontMatter,
+    body: doc.body,
     href: doc.href,
   };
   const result = config.plugins.reduce(function (acc, plugin) {

--- a/server.js
+++ b/server.js
@@ -85,7 +85,11 @@ function getNav(doc, allDocs, config) {
 function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
   let content = atRules(doc.body, config);
   const parsedContent = markdown(content, config);
-  const parsedContentWithFrontmatter = { ...parsedContent, ...doc.frontMatter };
+  const parsedContentWithFrontmatter = {
+    ...parsedContent,
+    ...doc.frontMatter,
+    href: doc.href,
+  };
   const result = config.plugins.reduce(function (acc, plugin) {
     return applyPlugin({ plugin, content: acc });
   }, parsedContentWithFrontmatter);


### PR DESCRIPTION
Each plugin may decide to change either the raw body or the parsed markdown content. 
Citadel to send both to the plugins