### PR TITLE
fix: passing complete mdx content to search plugin

### DIFF
--- a/server.js
+++ b/server.js
@@ -88,7 +88,7 @@ function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
   const parsedContentWithFrontmatter = {
     ...parsedContent,
     ...doc.frontMatter,
-    body: doc.body,
+    body: content,
     href: doc.href,
   };
   const result = config.plugins.reduce(function (acc, plugin) {


### PR DESCRIPTION
## Problem
- Currently while searching for any keyword in the docs, the results show `@include` statements rather than data of that file.
![image](https://user-images.githubusercontent.com/8402454/129870849-0ecfb851-d3a3-4cea-81e0-74b65675a47f.png)
## Reason
- This [file](https://github.com/razorpay/docs/blob/poc/docs-universe-ssg/src/routes/payment-links/reminders.md) includes a partial file.
- The content which is passed to the search plugin during the build for indexing, contains the raw markdown data of that file (i.e. containing `@include` statements) rather than the actual data of the imported file. Due to which the search results show incorrect data.
## Changes
- I am just passing the final compiled markdown to the search plugin
