### PR TITLE
Add file support

### DIFF
--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -55,6 +55,14 @@ module.exports = function (body, config) {
         return '';
       }
     )
+    .replace(
+      /^(\s*)(<file[^>]*>)(.*?)<\/file>/gms,
+      function (_, indent, openTag, content) {
+        attrs = getAttrs(openTag);
+        const updatedContent = `<a href="${attrs.href}" target="_blank" rel="noreferrer">${content}</a>`;
+        return `${indent}${updatedContent}`;
+      }
+    )
     .replace(/^(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
       attrs = getAttrs(openTag);
       if (attrs.src) {


### PR DESCRIPTION
## What?

File component can be used to download files. These files are assets like .csv, .zip, etc which are added to the assets folder and uploaded to S3. The file component will be replaced with an a tag that automatically opens up in a new window. 

## Why?

Content authors are currently using an a tag manually and setting the href as the file's path. Once we move to the CMS and the new system, we want to make their lives easier by providing a component instead

## Changes

- Parse file component using regex match and return an a tag with appropriate attributes set.
