### PR TITLE
fix: extract images inside other tags

### DIFF
--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -63,7 +63,7 @@ module.exports = function (body, config) {
         return `${indent}${updatedContent}`;
       }
     )
-    .replace(/^(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
+    .replace(/(\s*)<img([^>]*)\/?>/gm, function (openTag, indent) {
       attrs = getAttrs(openTag);
       if (attrs.src) {
         const isInternalImage = attrs.src.startsWith('/docs/');


### PR DESCRIPTION
## Description

Images can be put inside different tags such as "a" tag etc. These images need to be parsed and process by the at-rules processor

## Changes

Img tag need not be present at the start of a file. Update regex to read img tag anywhere