### PR TITLE
feat: match file tag anywhere in markdown

### DIFF
--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -56,7 +56,7 @@ module.exports = function (body, config) {
       }
     )
     .replace(
-      /^(\s*)(<file[^>]*>)(.*?)<\/file>/gms,
+      /(\s*)(<file[^>]*>)(.*?)<\/file>/gms,
       function (_, indent, openTag, content) {
         attrs = getAttrs(openTag);
         const updatedContent = `<a href="${attrs.href}" target="_blank" rel="noreferrer">${content}</a>`;


### PR DESCRIPTION
## Description
File tags can be put within other tags. However, the current regex expects the file tag to start at the beginning of a new file. Change the regex to allow to parse file tags anywhere in the content

## Changes
- Update regex