### PR TITLE
feat: add build search script

### DIFF
--- a/build-helpers.js
+++ b/build-helpers.js
@@ -1,0 +1,78 @@
+const {
+  cfs,
+  dir,
+} = require('./fs-helpers');
+const frontMatter = require('front-matter');
+
+async function getFormattedDoc({ allDocs, getPath }) {
+  return async function getDoc(key) {
+    if (allDocs.hasOwnProperty(key)) return allDocs[key];
+
+    let contents;
+    try {
+      contents = await cfs.read(getPath(key));
+    } catch (e) {
+      console.error(`Doc not found: ${key}`);
+      return;
+    }
+    const { attributes, body } = frontMatter(contents);
+    const href = key.replace(/(^|\/)index$/, '');
+    const doc = {
+      key,
+      frontMatter: attributes,
+      body,
+      href,
+      tree: formatTree({ tree: attributes.tree || '', key }),
+    };
+    allDocs[key] = doc;
+    doc.index = await getIndex({ doc, getPath, getDoc });
+    if (doc.index !== key) {
+      const indexDoc = allDocs[doc.index];
+      doc.frontMatter = { ...indexDoc.frontMatter, ...attributes };
+    }
+    return doc;
+  };
+}
+
+function formatTree({ tree, key }) {
+  return tree
+    .split('\n')
+    .filter((_) => _)
+    .map((line) => {
+      const split = line.split('|');
+      const level = split[0].match(/^\s+/)?.[0].length / 2 || 0;
+      const title = split.length > 1 && split.slice(1).join('|').trim();
+      const navKey = split[0].trim();
+
+      return {
+        key: navKey && dir(key) + '/' + navKey,
+        title,
+        level,
+      };
+    });
+}
+
+async function getIndex({ doc, getPath, getDoc }) {
+  if (doc.frontMatter.tree) {
+    return doc.key;
+  }
+  const split = doc.key.split('/');
+  for (let i = split.length - 1; i >= 0; i--) {
+    const maybeKey = split.slice(0, i).concat('index').join('/');
+    if (maybeKey === doc.key) continue;
+    const file = await cfs.read(getPath(maybeKey));
+    if (file) {
+      const maybeDoc = await getDoc(maybeKey);
+      if (maybeDoc.tree.find((t) => t.key === doc.key || t.key === doc.href)) {
+        return maybeKey;
+      }
+    } else {
+      continue;
+    }
+  }
+  return doc.key;
+}
+
+module.exports = {
+  getFormattedDoc,
+};

--- a/build-search.js
+++ b/build-search.js
@@ -1,0 +1,71 @@
+const glob = require('glob').sync;
+const { initializePlugin, applyPlugin, cleanupPlugin } = require('./plugins');
+const getMarkdown = require('./scripts/md');
+const atRules = require('./scripts/at-rules');
+const {
+  getDocumentsRoot,
+  getDocumentsGlob
+} = require('./fs-helpers');
+const { getFormattedDoc } = require('./build-helpers');
+
+const markdownExtension = '.md';
+let plugin = {};
+
+function checkAllowed(key, config) {
+  let allow = true;
+  config.rules.forEach((rule) => {
+    if (key.startsWith(rule.slice(1))) {
+      allow = rule[0] === '+';
+    }
+  });
+  return allow;
+}
+
+const build = async (config) => {
+  const markdown = getMarkdown(config);
+
+  const documentsRoot = getDocumentsRoot(config);
+  const getKey = (path) =>
+    path.slice(documentsRoot.length + 1, -markdownExtension.length);
+    
+  const getPath = (key) => documentsRoot + '/' + key + markdownExtension;
+
+  const getDoc = await getFormattedDoc({ allDocs: {}, getPath });
+
+  const docs = glob(getDocumentsGlob(config, markdownExtension));
+  
+  const docsWithContent = await Promise.all(
+    docs
+      .map((d) => {
+        const key = getKey(d);
+        return checkAllowed(key, config) && getDoc(key);
+      })
+      .filter((_) => _)
+  );
+
+  docsWithContent.forEach((doc) => {
+    let content = atRules(doc.body, config);
+    const parsedContent = markdown(content, config);
+    const parsedContentWithFrontmatter = {
+      ...parsedContent,
+      ...doc.frontMatter,
+      body: content,
+      href: doc.href,
+    };
+    applyPlugin({ plugin, content: parsedContentWithFrontmatter });
+  });
+}
+
+const buildSearch = async (configs) => {
+  plugin = configs[0].plugins[0];
+  initializePlugin(plugin, configs[0]);
+  const promises = configs.map(config => build(config));
+  return Promise.all(promises).then(() => {
+    cleanupPlugin(plugin);
+    return true;
+  });
+}
+
+module.exports = {
+  buildSearch,
+};

--- a/build-search.js
+++ b/build-search.js
@@ -1,3 +1,10 @@
+/**
+ * Problem 
+ * CMS content and direct changes that are done in src/routes trigger 2 separate deploy actions and due to which, search.json of one workflow is overridden by the other
+ * Due to this CMS pages changes don't show up in search results
+ * Solution 
+ * adds script for building seach.json file independently from the file build folder
+ */
 const glob = require('glob').sync;
 const { initializePlugin, applyPlugin, cleanupPlugin } = require('./plugins');
 const getMarkdown = require('./scripts/md');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 'use strict';
 const glob = require('glob').sync;
-const frontMatter = require('front-matter');
 const argv = require('yargs-parser')(process.argv.slice(2));
+const { getFormattedDoc } = require('./build-helpers');
 const {
-  cfs,
-  dir,
   getDocumentsRoot,
   getDocumentsGlob,
 } = require('./fs-helpers');
@@ -12,15 +10,21 @@ const { readConfig } = require('./read-config');
 const path = require('path');
 
 const isServer = argv._.indexOf('serve') !== -1;
+const isSearch = argv._.indexOf('build-search') !== -1;
 const { serve, build } = require('./server');
+const { buildSearch } = require('./build-search');
 
 const markdownExtension = '.md';
 readConfig().then((configs) => {
-  return Promise.all(
-    configs.map(async (config) => {
-      await compile(config);
-    })
-  );
+  if (isSearch) {
+    return buildSearch(configs);
+  } else {
+    return Promise.all(
+      configs.map(async (config) => {
+        await compile(config);
+      })
+    );
+  }
 });
 
 async function compile(config) {
@@ -48,73 +52,4 @@ async function compile(config) {
       allDocs,
     });
   }
-}
-
-async function getFormattedDoc({ allDocs, getPath }) {
-  return async function getDoc(key) {
-    if (allDocs.hasOwnProperty(key)) return allDocs[key];
-
-    let contents;
-    try {
-      contents = await cfs.read(getPath(key));
-    } catch (e) {
-      console.error(`Doc not found: ${key}`);
-      return;
-    }
-    const { attributes, body } = frontMatter(contents);
-    const href = key.replace(/(^|\/)index$/, '');
-    const doc = {
-      key,
-      frontMatter: attributes,
-      body,
-      href,
-      tree: formatTree({ tree: attributes.tree || '', key }),
-    };
-    allDocs[key] = doc;
-    doc.index = await getIndex({ doc, getPath, getDoc });
-    if (doc.index !== key) {
-      const indexDoc = allDocs[doc.index];
-      doc.frontMatter = { ...indexDoc.frontMatter, ...attributes };
-    }
-    return doc;
-  };
-}
-
-function formatTree({ tree, key }) {
-  return tree
-    .split('\n')
-    .filter((_) => _)
-    .map((line) => {
-      const split = line.split('|');
-      const level = split[0].match(/^\s+/)?.[0].length / 2 || 0;
-      const title = split.length > 1 && split.slice(1).join('|').trim();
-      const navKey = split[0].trim();
-
-      return {
-        key: navKey && dir(key) + '/' + navKey,
-        title,
-        level,
-      };
-    });
-}
-
-async function getIndex({ doc, getPath, getDoc }) {
-  if (doc.frontMatter.tree) {
-    return doc.key;
-  }
-  const split = doc.key.split('/');
-  for (let i = split.length - 1; i >= 0; i--) {
-    const maybeKey = split.slice(0, i).concat('index').join('/');
-    if (maybeKey === doc.key) continue;
-    const file = await cfs.read(getPath(maybeKey));
-    if (file) {
-      const maybeDoc = await getDoc(maybeKey);
-      if (maybeDoc.tree.find((t) => t.key === doc.key || t.key === doc.href)) {
-        return maybeKey;
-      }
-    } else {
-      continue;
-    }
-  }
-  return doc.key;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@arr/every": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
-      "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg=="
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
@@ -28,11 +23,6 @@
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
-    },
-    "@polka/url": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
-      "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw=="
     },
     "@types/eslint": {
       "version": "7.2.13",
@@ -1053,14 +1043,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
       "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
     },
-    "matchit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
-      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
-      "requires": {
-        "@arr/every": "^1.0.0"
-      }
-    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -1195,15 +1177,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
-    },
-    "polka": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/polka/-/polka-0.5.2.tgz",
-      "integrity": "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==",
-      "requires": {
-        "@polka/url": "^0.5.0",
-        "trouter": "^2.0.1"
-      }
     },
     "promise": {
       "version": "7.3.1",
@@ -1646,14 +1619,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
-    },
-    "trouter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/trouter/-/trouter-2.0.1.tgz",
-      "integrity": "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==",
-      "requires": {
-        "matchit": "^1.0.0"
-      }
     },
     "type-is": {
       "version": "1.6.18",


### PR DESCRIPTION
## Problem
- CMS content and direct changes that are done in `src/routes` trigger 2 separate deploy actions and due to which, search.json of one workflow is overridden by the other
- Due to this CMS pages changes don't show up in search results

## Solution
- adds script for building seach.json file independently from the file build folder