### PR TITLE
add base path in config

### DIFF
--- a/generate-js.js
+++ b/generate-js.js
@@ -9,6 +9,7 @@ function generateJs({ config }) {
       ...webpackConfigBase.plugins,
       new webpack.DefinePlugin({
         ORG: JSON.stringify(config.org),
+        BASE_PATH: JSON.stringify(config.basePath),
         PUBLIC_PATH: JSON.stringify(config.publicPath),
         DASHBOARD_URL: JSON.stringify(config.dashboardUrl),
         X_DASHBOARD_URL: JSON.stringify(config.xDashboardUrl),


### PR DESCRIPTION
Problem
Home page search results redirect to cloudfront URL of the page

Solution
adds base path in config which would be used by search results in the website