### PR TITLE
refactor: removed create config step in serve

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,15 @@
 const glob = require('glob').sync;
 const argv = require('yargs-parser')(process.argv.slice(2));
 const { getFormattedDoc } = require('./build-helpers');
-const {
-  getDocumentsRoot,
-  getDocumentsGlob,
-} = require('./fs-helpers');
+const { getDocumentsRoot, getDocumentsGlob } = require('./fs-helpers');
+const createRedirects = require('./create-redirects');
 const { readConfig } = require('./read-config');
 const path = require('path');
 
 const isServer = argv._.indexOf('serve') !== -1;
 const isSearch = argv._.indexOf('build-search') !== -1;
+const shouldCreateRedirects = argv._.indexOf('create-redirect') !== -1;
+
 const { serve, build } = require('./server');
 const { buildSearch } = require('./build-search');
 
@@ -35,6 +35,10 @@ async function compile(config) {
   const allDocs = {};
   const getDoc = await getFormattedDoc({ allDocs, getPath });
 
+  if (shouldCreateRedirects) {
+    createRedirects(config);
+    return;
+  }
   if (isServer) {
     serve({
       config,

--- a/server.js
+++ b/server.js
@@ -143,7 +143,7 @@ const serve = ({ config, getDoc, getPath, allDocs, getKey }) => {
       if (err) throw err;
       console.log(`> Running ${config.org} on http://localhost:${config.port}`);
     });
-  createRedirects(config);
+  // createRedirects(config); not needed in case of serve
 };
 
 async function build({ config, getDoc, docs, getKey, allDocs }) {

--- a/server.js
+++ b/server.js
@@ -143,7 +143,6 @@ const serve = ({ config, getDoc, getPath, allDocs, getKey }) => {
       if (err) throw err;
       console.log(`> Running ${config.org} on http://localhost:${config.port}`);
     });
-  // createRedirects(config); not needed in case of serve
 };
 
 async function build({ config, getDoc, docs, getKey, allDocs }) {


### PR DESCRIPTION
Problem: redirect files were being written every time a serve command from citadel was being run. All the files were being written regardless of changed files due to which serve was taking about 20 sec to complete.

Hence removed createRedirects step in case of serve (needed in case of build only).