### PR TITLE
add html attributes validation util

### DIFF
--- a/build-search.js
+++ b/build-search.js
@@ -51,7 +51,7 @@ const build = async (config) => {
   );
 
   docsWithContent.forEach((doc) => {
-    let content = atRules(doc.body, config, doc.frontMatter.title, doc.key);
+    let content = atRules(doc.body, config, doc.key);
     const parsedContent = markdown(content, config);
     const parsedContentWithFrontmatter = {
       ...parsedContent,

--- a/build-search.js
+++ b/build-search.js
@@ -51,7 +51,7 @@ const build = async (config) => {
   );
 
   docsWithContent.forEach((doc) => {
-    let content = atRules(doc.body, config);
+    let content = atRules(doc.body, config, doc.frontMatter.title, doc.key);
     const parsedContent = markdown(content, config);
     const parsedContentWithFrontmatter = {
       ...parsedContent,

--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -41,22 +41,17 @@ function validateRequiredAttributes(tag = '', userGivenAttributes = {}, required
   // else validation will run for same files for other orgs as well
   if (config.org !== 'razorpay') return;
 
-  try {
-    const requiredAttributesNotPresent = [];
-    requiredAttributes.forEach(attribute => {
-      if (!userGivenAttributes[attribute]) {
-        filesHaveSyntaxError = true;
-        requiredAttributesNotPresent.push(attribute);
-      }
-    });
-
-    if (requiredAttributesNotPresent.length) {
-      console.log(`'${requiredAttributesNotPresent.join(', ')}' missing at path: '${getDocumentsRoot(config)}/${docPath}' for '${tag.trim()}'`);
-      process.exit(1);
+  const requiredAttributesNotPresent = [];
+  requiredAttributes.forEach(attribute => {
+    if (!userGivenAttributes[attribute]) {
+      filesHaveSyntaxError = true;
+      requiredAttributesNotPresent.push(attribute);
     }
-  } catch(err) {
-    console.log(err);
-    // don't want to break the build if some logic messes up here
+  });
+
+  if (requiredAttributesNotPresent.length) {
+    console.log(`'${requiredAttributesNotPresent.join(', ')}' missing at path: '${getDocumentsRoot(config)}/${docPath}' for '${tag.trim()}'`);
+    process.exit(1);
   }
 }
 

--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -60,7 +60,7 @@ function validateRequiredAttributes(tag = '', userGivenAttributes = {}, required
   }
 }
 
-module.exports = function (body, config, title, docPath) {
+module.exports = function (body, config, docPath) {
   return body
     .replace(
       /^(\s*)@(\/\/|image|include)(.*)$/gm,

--- a/scripts/at-rules.js
+++ b/scripts/at-rules.js
@@ -33,14 +33,17 @@ const requiredAttributesByTags = {
 
 function getAttrs(openTag, docPath, config) {
   let attrs = {};
+  let tagName;
+
   const parser = new htmlparser.Parser({
     onopentag(name, _attrs) {
-      validateAttributes(openTag, _attrs, requiredAttributesByTags[name], docPath, config);
       attrs = _attrs;
+      tagName = name;
     },
   });
   parser.write(openTag);
   parser.end();
+  validateAttributes(openTag, attrs, requiredAttributesByTags[tagName], docPath, config);
   return attrs;
 }
 

--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ function getNav(doc, allDocs, config) {
 }
 
 function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
-  let content = atRules(doc.body, config, doc.frontMatter.title, doc.key);
+  let content = atRules(doc.body, config, doc.key);
   const parsedContent = markdown(content, config);
   const parsedContentWithFrontmatter = {
     ...parsedContent,
@@ -143,7 +143,6 @@ const serve = ({ config, getDoc, getPath, allDocs, getKey }) => {
       if (err) throw err;
       console.log(`> Running ${config.org} on http://localhost:${config.port}`);
     });
-  createRedirects(config);
 };
 
 async function build({ config, getDoc, docs, getKey, allDocs }) {

--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ function getNav(doc, allDocs, config) {
 }
 
 function compileDoc({ doc, config, pugCompiler, allDocs, markdown }) {
-  let content = atRules(doc.body, config);
+  let content = atRules(doc.body, config, doc.frontMatter.title, doc.key);
   const parsedContent = markdown(content, config);
   const parsedContentWithFrontmatter = {
     ...parsedContent,
@@ -143,6 +143,7 @@ const serve = ({ config, getDoc, getPath, allDocs, getKey }) => {
       if (err) throw err;
       console.log(`> Running ${config.org} on http://localhost:${config.port}`);
     });
+  createRedirects(config);
 };
 
 async function build({ config, getDoc, docs, getKey, allDocs }) {


### PR DESCRIPTION
# Changes
- Adds util in `at-rules` script to validate missing required attributes and having value `undefined` in HTML and fail the build on validation fail
- This change is required to prevent the build to pass with buggy content
- More context on the issue that happened [here](https://github.com/razorpay/docs/pull/4407)

Example error message for required attributes missing 👇
![image](https://user-images.githubusercontent.com/8402454/145814576-4fc09c67-3714-4cd1-b444-99880e57dd64.png)

Example error message for attribute with value `undefined` 👇 
![image](https://user-images.githubusercontent.com/8402454/145814660-0568632d-128f-4a0e-b10d-5a3f43ca5c99.png)
 
