### PR TITLE
feat: fail build on file at path defined in tree doesn't exist

### DIFF
--- a/build-helpers.js
+++ b/build-helpers.js
@@ -4,7 +4,7 @@ const {
 } = require('./fs-helpers');
 const frontMatter = require('front-matter');
 
-async function getFormattedDoc({ allDocs, getPath }) {
+async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
   return async function getDoc(key) {
     if (allDocs.hasOwnProperty(key)) return allDocs[key];
 
@@ -22,7 +22,7 @@ async function getFormattedDoc({ allDocs, getPath }) {
       frontMatter: attributes,
       body,
       href,
-      tree: formatTree({ tree: attributes.tree || '', key }),
+      tree: formatTree({ tree: attributes.tree || '', key, getPath, filePathsDontExist }),
     };
     allDocs[key] = doc;
     doc.index = await getIndex({ doc, getPath, getDoc });
@@ -34,7 +34,7 @@ async function getFormattedDoc({ allDocs, getPath }) {
   };
 }
 
-function formatTree({ tree, key }) {
+function formatTree({ tree, key, getPath, filePathsDontExist }) {
   return tree
     .split('\n')
     .filter((_) => _)
@@ -43,6 +43,22 @@ function formatTree({ tree, key }) {
       const level = split[0].match(/^\s+/)?.[0].length / 2 || 0;
       const title = split.length > 1 && split.slice(1).join('|').trim();
       const navKey = split[0].trim();
+      
+      /** We are checking if paths given in the tree file exists or not
+       *  we are pushing all the file paths that don't exist in an array
+       *  and the build would fail at the end listing all these file paths
+       */
+      if (navKey && navKey !== 'index') {
+        const filePath = key.replace(/(^|\/)index$/, '') + '/' + navKey;
+        const content = cfs.readSync(getPath(filePath));
+
+        if (!content && !filePathsDontExist.find(obj => obj.filePath === filePath)) {
+          filePathsDontExist.push({
+            filePath,
+            treeFilePath: key
+          });
+        }
+      }
 
       return {
         key: navKey && dir(key) + '/' + navKey,

--- a/build-helpers.js
+++ b/build-helpers.js
@@ -39,9 +39,12 @@ function formatTree({ tree, key, getPath, filePathsDontExist }) {
     .split('\n')
     .filter((_) => _)
     .map((line) => {
+      // 'folder-name | title' format is split here
       const split = line.split('|');
       const level = split[0].match(/^\s+/)?.[0].length / 2 || 0;
       const title = split.length > 1 && split.slice(1).join('|').trim();
+      // 'folder-name' from the above split is stored in navKey
+      // which will be used as a link to the page while generating navigation
       const navKey = split[0].trim();
       
       /** We are checking if paths given in the tree file exists or not

--- a/index.js
+++ b/index.js
@@ -28,12 +28,13 @@ readConfig().then((configs) => {
 });
 
 async function compile(config) {
+  const filePathsDontExist = [];
   const documentsRoot = getDocumentsRoot(config);
   const getKey = (path) =>
     path.slice(documentsRoot.length + 1, -markdownExtension.length);
   const getPath = (key) => documentsRoot + '/' + key + markdownExtension;
   const allDocs = {};
-  const getDoc = await getFormattedDoc({ allDocs, getPath });
+  const getDoc = await getFormattedDoc({ allDocs, getPath, config, filePathsDontExist });
 
   if (shouldCreateRedirects) {
     createRedirects(config);
@@ -46,6 +47,7 @@ async function compile(config) {
       getPath,
       getKey,
       allDocs,
+      filePathsDontExist,
     });
   } else {
     build({
@@ -54,6 +56,7 @@ async function compile(config) {
       docs: glob(getDocumentsGlob(config, markdownExtension)),
       getKey,
       allDocs,
+      filePathsDontExist,
     });
   }
 }

--- a/server.js
+++ b/server.js
@@ -144,7 +144,7 @@ const serve = ({ config, getDoc, getPath, allDocs, getKey }) => {
     );
     const html = compileDoc({ doc, config, pugCompiler, allDocs, markdown });
     if (filePathsDontExist.length) {
-      console.log(filePathsDontExist);
+      console.error(filePathsDontExist);
       process.exit(1);
     }
     res.end(html);
@@ -184,7 +184,7 @@ async function build({ config, getDoc, docs, getKey, allDocs }) {
     cfs.write(filepath, html);
   });
   if (filePathsDontExist.length) {
-    console.log(filePathsDontExist);
+    console.error(filePathsDontExist);
     process.exit(1);
   }
   createRedirects(config);

--- a/server.js
+++ b/server.js
@@ -56,7 +56,17 @@ function getNav(doc, allDocs, config) {
       if (!checkAllowed(key, config)) return;
       if (!allDocs[key] && allDocs[key + '/index']) key = key + '/index';
     }
-    const title = d.title || allDocs[key]?.frontMatter.title || '';
+    const title = d.title || allDocs[key]?.frontMatter.title;
+
+    /**
+     * this means that the path defined in 'tree' is not correct
+     * currently the build doesn't in this case and an empty element is shown in docs site
+     * throwing an error and exiting in this case
+    */
+    if (!title && !allDocs[key]) {
+      console.log(`buildNavigation: Found file with issue at path: '${key}' \nPlease check 'tree' at path '${doc.index}' if the paths are correctly defined in it.`)
+      process.exit(1);
+    }
 
     const item = {
       key,

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ function getNav(doc, allDocs, config) {
     /**
      * this means that the path defined in 'tree' is not correct
      * currently the build doesn't fail in this case due to this an empty element is shown in docs site in left sidebar
-     * throwing an error and exiting in this case
+     * pushing all the errors to an array and throwing it all at once in build and exiting
     */
     if (!title && !allDocs[key]) {
       const err = `buildNavigation: File at path: '${key}' not found \nPlease check 'tree' at '${doc.index}' if the paths are correctly defined`;

--- a/server.js
+++ b/server.js
@@ -60,11 +60,11 @@ function getNav(doc, allDocs, config) {
 
     /**
      * this means that the path defined in 'tree' is not correct
-     * currently the build doesn't in this case and an empty element is shown in docs site
+     * currently the build doesn't fail in this case due to this an empty element is shown in docs site in left sidebar
      * throwing an error and exiting in this case
     */
     if (!title && !allDocs[key]) {
-      console.log(`buildNavigation: Found file with issue at path: '${key}' \nPlease check 'tree' at path '${doc.index}' if the paths are correctly defined in it.`)
+      console.log(`buildNavigation: File at path: '${key}' not found \nPlease check 'tree' at '${doc.index}' if the paths are correctly defined`)
       process.exit(1);
     }
 


### PR DESCRIPTION
# Issue
- Currently, there's no check in the build system if paths defined in `tree` exist or not
- If a folder doesn't exist at the path given in `tree`, [an empty item is seen in the left sidebar](https://razorpay.com/docs/x/quickbooks/delete/) 👇  
![image](https://user-images.githubusercontent.com/8402454/154054960-4d1be4d4-04bb-4964-9ffb-4821bbb4fc16.png)

# Expected behaviour 
- The expected behaviour is the build should fail with an error instead of successfully completing

# Changes
- To fix the above issue, this PR refactors the build script to fail if the path defined in `tree` doesn't exist with an error 👇 
![image](https://user-images.githubusercontent.com/8402454/155268784-60dbd174-834c-4dfc-9f3d-0cf3a3ff2bce.png)
