### PR TITLE
fix: added code to add default indexDoc when indexDoc's tree is not there

### DIFF
--- a/build-helpers.js
+++ b/build-helpers.js
@@ -26,7 +26,7 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
     };
     allDocs[key] = doc;
     doc.index = await getIndex({ doc, getPath, getDoc });
-    // if current doc's index doesn't have tree, we set it to '/index'
+    // if current doc's index doesn't have tree, we set it to '{root directory}/index'
     if (allDocs[doc.index].tree.length === 0) {
       await getDoc('/index');
       doc.index= '/index';
@@ -72,6 +72,11 @@ function formatTree({ tree, key, getPath, filePathsDontExist }) {
       }
 
       return {
+        /* 
+           as the mapped (in allDocs) key is used as a link to the page, which don't starts with '/'
+           we need to remove '/' from the beginning of the key
+           hence only adding '/' if dir(key) is not empty
+        */
         key: navKey && dir(key) + (dir(key) && '/') + navKey,
         title,
         level,

--- a/build-helpers.js
+++ b/build-helpers.js
@@ -26,6 +26,9 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
     };
     allDocs[key] = doc;
     doc.index = await getIndex({ doc, getPath, getDoc });
+    if (allDocs[doc.index].tree.length === 0) {
+      doc.index = '/index';
+    }
     if (doc.index !== key) {
       const indexDoc = allDocs[doc.index];
       doc.frontMatter = { ...indexDoc.frontMatter, ...attributes };
@@ -46,7 +49,7 @@ function formatTree({ tree, key, getPath, filePathsDontExist }) {
       // 'folder-name' from the above split is stored in navKey
       // which will be used as a link to the page while generating navigation
       const navKey = split[0].trim();
-      
+
       /** We are checking if paths given in the tree file exists or not
        *  we are pushing all the file paths that don't exist in an array
        *  and the build would fail at the end listing all these file paths
@@ -55,10 +58,13 @@ function formatTree({ tree, key, getPath, filePathsDontExist }) {
         const filePath = key.replace(/(^|\/)index$/, '') + '/' + navKey;
         const content = cfs.readSync(getPath(filePath));
 
-        if (!content && !filePathsDontExist.find(obj => obj.filePath === filePath)) {
+        if (
+          !content &&
+          !filePathsDontExist.find((obj) => obj.filePath === filePath)
+        ) {
           filePathsDontExist.push({
             filePath,
-            treeFilePath: key
+            treeFilePath: key,
           });
         }
       }

--- a/build-helpers.js
+++ b/build-helpers.js
@@ -26,8 +26,10 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
     };
     allDocs[key] = doc;
     doc.index = await getIndex({ doc, getPath, getDoc });
+    // if current doc's index doesn't have tree, we set it to '/index'
     if (allDocs[doc.index].tree.length === 0) {
-      doc.index = '/index';
+      await getDoc('/index');
+      doc.index= '/index';
     }
     if (doc.index !== key) {
       const indexDoc = allDocs[doc.index];

--- a/build-helpers.js
+++ b/build-helpers.js
@@ -72,7 +72,7 @@ function formatTree({ tree, key, getPath, filePathsDontExist }) {
       }
 
       return {
-        key: navKey && dir(key) + '/' + navKey,
+        key: navKey && dir(key) + (dir(key) && '/') + navKey,
         title,
         level,
       };

--- a/fs-helpers.js
+++ b/fs-helpers.js
@@ -5,7 +5,11 @@ const getDocumentsRoot = (config) => path.resolve(config.src);
 const getPluginsRoot = (config) => path.resolve(config.pluginRoot || '');
 const getDocumentsGlob = (config) =>
   `${getDocumentsRoot(config)}/**/*${markdownExtension}`;
-const dir = (str) => str.replace(/\/[^/]+$/, '');
+const dir = (str) => {
+  // for index file in the root directory return empty string
+  if(str==='index') return '';
+  return str.replace(/\/[^/]+$/, '');
+}
 
 module.exports = {
   cfs,

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function compile(config) {
   const documentsRoot = getDocumentsRoot(config);
   const getKey = (path) =>
     path.slice(documentsRoot.length + 1, -markdownExtension.length);
-  const getPath = (key) => documentsRoot + '/' + key + markdownExtension;
+  const getPath = (key) => documentsRoot + (key.startsWith('/')?'':'/') + key + markdownExtension;
   const allDocs = {};
   const getDoc = await getFormattedDoc({ allDocs, getPath, config, filePathsDontExist });
 


### PR DESCRIPTION
# Description:
The current Citadel structures assumes the tree in a doc to be present either in the doc or any of it's closest parent till L0. But in case of our current Idocs we have all the tree defined only in main `index.md` file. Due to which Idocs was failing with the new version of citadel.

## What's in this PR
This PR contains the fix for above issue. The corresponding IDocs PR can be found [here](https://github.com/razorpay/idocs/pull/132)
