### PR TITLE
feat: add support for heading in frontmatter

### DIFF
--- a/build-helpers.js
+++ b/build-helpers.js
@@ -13,14 +13,15 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
       return;
     }
     const { attributes, body } = frontMatter(contents);
+    const normalizedAttributes = normalizeFrontmatter(attributes);
     const href = key.replace(/(^|\/)index$/, '');
     const doc = {
       key,
-      frontMatter: normalizeFrontmatter(attributes),
+      frontMatter: normalizedAttributes,
       body,
       href,
       tree: formatTree({
-        tree: attributes.tree || '',
+        tree: normalizedAttributes.tree || '',
         key,
         getPath,
         filePathsDontExist,
@@ -35,7 +36,7 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
     }
     if (doc.index !== key) {
       const indexDoc = allDocs[doc.index];
-      doc.frontMatter = { ...indexDoc.frontMatter, ...attributes };
+      doc.frontMatter = { ...indexDoc.frontMatter, ...normalizedAttributes };
     }
     return doc;
   };

--- a/build-helpers.js
+++ b/build-helpers.js
@@ -1,7 +1,4 @@
-const {
-  cfs,
-  dir,
-} = require('./fs-helpers');
+const { cfs, dir } = require('./fs-helpers');
 const frontMatter = require('front-matter');
 
 async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
@@ -19,17 +16,22 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
     const href = key.replace(/(^|\/)index$/, '');
     const doc = {
       key,
-      frontMatter: attributes,
+      frontMatter: normalizeFrontmatter(attributes),
       body,
       href,
-      tree: formatTree({ tree: attributes.tree || '', key, getPath, filePathsDontExist }),
+      tree: formatTree({
+        tree: attributes.tree || '',
+        key,
+        getPath,
+        filePathsDontExist,
+      }),
     };
     allDocs[key] = doc;
     doc.index = await getIndex({ doc, getPath, getDoc });
     // if current doc's index doesn't have tree, we set it to '{root directory}/index'
     if (allDocs[doc.index].tree.length === 0) {
       await getDoc('/index');
-      doc.index= '/index';
+      doc.index = '/index';
     }
     if (doc.index !== key) {
       const indexDoc = allDocs[doc.index];
@@ -103,6 +105,10 @@ async function getIndex({ doc, getPath, getDoc }) {
     }
   }
   return doc.key;
+}
+
+function normalizeFrontmatter(frontMatter = {}) {
+  return { ...frontMatter, heading: frontMatter.heading || frontMatter.title };
 }
 
 module.exports = {


### PR DESCRIPTION
# Description
Currently,  the title is being used as the heading for the page as well. This is not ideal as we may want different headings and titles. This PR adds support for the Heading field in frontmatter.

## Changes
- Add normalizeFrontmatter function
- Take heading from frontmatter if present, else take the title and set it as heading