### PR TITLE
fix: trim space and check for empty html tag

### DIFF
--- a/scripts/html_block.js
+++ b/scripts/html_block.js
@@ -82,7 +82,7 @@ module.exports = function (md, config) {
         max = state.eMarks[nextLine];
         lineText = state.src.slice(pos, max);
 
-        if (lineText.startsWith('</' + tagMatch[1])) {
+        if (lineText.trim().startsWith('</' + tagMatch[1])) {
           break;
         }
 


### PR DESCRIPTION
# What's the issue?
- In a few places, table renders an extra `td` 👇🏻. Check it live [here](https://razorpay.com/docs/payments/payment-gateway/ecommerce-plugins/wix/faqs/#2-i-am-getting-the-following-error-during)
<img width="778" alt="image" src="https://user-images.githubusercontent.com/8402454/181240114-c3d3c777-71cb-4c3d-859e-50a60901f94f.png">


# Why?
- This is happening because `<table>` tag isn't properly indented in the content. Check the indentation here https://raw.githubusercontent.com/razorpay/docs/master/production/content/routes/payments/payment-gateway/ecommerce-plugins/wix/faqs/index.md?token=GHSAT0AAAAAABUZBBCWBZ24A6AHTQS4EC2CYXBF3TQ
- I played around a bit and found the indentation to be the issue. As soon as I fix that, it seems to be rendering properly.
- Due to this, the ending `</table>` tag is received in the parsing function which renders it as an extra `td` in the row  

# Fix
- Keeping a check in custom HTML parser, if td content has </table> in it, then ignore it else push it to the final HTML string.
- Have deployed the fix [here](https://betasite.razorpay.com/docs/revamped/payments/payment-gateway/ecommerce-plugins/wix/faqs/#2-i-am-getting-the-following-error-during)