### PR TITLE
fix(tag): remove html override in markdown

### DIFF
--- a/scripts/html_block.js
+++ b/scripts/html_block.js
@@ -128,7 +128,7 @@ const customHtml = {
 }
 
 
-const raw_tags = ['script', 'style', 'pre', 'p', 'fence'];
+const raw_tags = ['script', 'style', 'pre', 'p', 'fence', 'iframe'];
 
 function doprocess(tag, lines, md, config) {
   if (tag in customHtml) {


### PR DESCRIPTION
Description: html tag override logic was causing issue while rendering raw iframe tag leading to messed up attribute value for the tag. Hence removed it from override itself.

https://razorpay.atlassian.net/browse/AC-404