### PR TITLE
fix(search): remove combining root frontmatter

### DIFF
--- a/build-helpers.js
+++ b/build-helpers.js
@@ -34,10 +34,6 @@ async function getFormattedDoc({ allDocs, getPath, filePathsDontExist }) {
       await getDoc('/index');
       doc.index = '/index';
     }
-    if (doc.index !== key) {
-      const indexDoc = allDocs[doc.index];
-      doc.frontMatter = { ...indexDoc.frontMatter, ...normalizedAttributes };
-    }
     return doc;
   };
 }


### PR DESCRIPTION
This PR removes the code that combines root doc frontmatter and current doc frontmatter. 
Combining the frontmatter had issues in overriding locale specific title and desc. 
[Slack Thread](https://razorpay.slack.com/archives/C03BD0J6DNC/p1681457705892469)